### PR TITLE
Enable yamllint strict mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_install:
 install:
   - pip install yamllint
 script:
-  - yamllint .
+  - yamllint --strict .
   - bash hack/test.sh

--- a/test_section_06_level1.yml
+++ b/test_section_06_level1.yml
@@ -77,28 +77,27 @@ command:
     stderr: []
     timeout: 10000
 
-# 6.2 User and Group Settings
-# 6.2.1 Ensure password fields are not empty (Scored)
-# 6.2.2 Ensure no legacy "+" entries exist in /etc/passwd (Scored)
-# 6.2.3 Ensure no legacy "+" entries exist in /etc/shadow (Scored)
-# 6.2.4 Ensure no legacy "+" entries exist in /etc/group (Scored)
-# 6.2.5 Ensure root is the only UID 0 account (Scored)
-# 6.2.6 Ensure root PATH Integrity (Scored)
-# 6.2.7 Ensure all users' home directories exist (Scored)
-# 6.2.8 Ensure users' home directories permissions are 750 or more restrictive (Scored)
-# 6.2.9 Ensure users own their home directories (Scored)
-# 6.2.10 Ensure users' dot files are not group or world writable (Scored)
-# 6.2.11 Ensure no users have .forward files (Scored)
-# 6.2.12 Ensure no users have .netrc files (Scored)
-# 6.2.13 Ensure users' .netrc Files are not group or world accessible (Scored)
-# 6.2.14 Ensure no users have .rhosts files (Scored)
-# 6.2.15 Ensure all groups in /etc/passwd exist in /etc/group (Scored)
-# 6.2.16 Ensure no duplicate UIDs exist (Scored)
-# 6.2.17 Ensure no duplicate GIDs exist (Scored)
-# 6.2.18 Ensure no duplicate user names exist (Scored)
-# 6.2.19 Ensure no duplicate group names exist (Scored)
-# 6.2.20 Ensure shadow group is empty (Scored)
-
+  # 6.2 User and Group Settings
+  # 6.2.1 Ensure password fields are not empty (Scored)
+  # 6.2.2 Ensure no legacy "+" entries exist in /etc/passwd (Scored)
+  # 6.2.3 Ensure no legacy "+" entries exist in /etc/shadow (Scored)
+  # 6.2.4 Ensure no legacy "+" entries exist in /etc/group (Scored)
+  # 6.2.5 Ensure root is the only UID 0 account (Scored)
+  # 6.2.6 Ensure root PATH Integrity (Scored)
+  # 6.2.7 Ensure all users' home directories exist (Scored)
+  # 6.2.8 Ensure users' home directories permissions are 750 or more restrictive (Scored)
+  # 6.2.9 Ensure users own their home directories (Scored)
+  # 6.2.10 Ensure users' dot files are not group or world writable (Scored)
+  # 6.2.11 Ensure no users have .forward files (Scored)
+  # 6.2.12 Ensure no users have .netrc files (Scored)
+  # 6.2.13 Ensure users' .netrc Files are not group or world accessible (Scored)
+  # 6.2.14 Ensure no users have .rhosts files (Scored)
+  # 6.2.15 Ensure all groups in /etc/passwd exist in /etc/group (Scored)
+  # 6.2.16 Ensure no duplicate UIDs exist (Scored)
+  # 6.2.17 Ensure no duplicate GIDs exist (Scored)
+  # 6.2.18 Ensure no duplicate user names exist (Scored)
+  # 6.2.19 Ensure no duplicate group names exist (Scored)
+  # 6.2.20 Ensure shadow group is empty (Scored)
   cat /etc/shadow | awk -F':' '($2 == "" )':
     exit-status: 0
     stderr: []


### PR DESCRIPTION
By default the script will exit with a return code 1 only when there is one or more error(s).

However if strict mode is enabled with the -s (or --strict) option, the return code will be:

```
0 if no errors or warnings occur
1 if one or more errors occur
2 if no errors occur, but one or more warnings occur
```