### PR TITLE
Adjust tests for sections 6.1.13 and 6.1.14

### DIFF
--- a/scripts/test_section_06_level1/6-1-13.sh
+++ b/scripts/test_section_06_level1/6-1-13.sh
@@ -21,14 +21,14 @@ curl -v -H Metadata-Flavor:Google $url_google -f > /dev/null 2>&1 || status=1
 
 if [[ "${status}x" == "0x" ]]; then
   if [[ $count_SUID == "$gcp_binaries" ]]; then
-    exit 0
-  else
     exit 1
+  else
+    exit 0
   fi
 fi
 
 if [[ $count_SUID == "$azure_binaries" ]]; then
-  exit 0
-else
   exit 1
+else
+  exit 0
 fi

--- a/scripts/test_section_06_level1/6-1-14.sh
+++ b/scripts/test_section_06_level1/6-1-14.sh
@@ -21,14 +21,14 @@ curl -v -H Metadata-Flavor:Google $url_google -f > /dev/null 2>&1 || status=1
 
 if [[ "${status}x" == "0x" ]]; then
   if [[ $count_SGID == "$gcp_binaries" ]]; then
-    exit 0
-  else
     exit 1
+  else
+    exit 0
   fi
 fi
 
 if [[ $count_SGID == "$azure_binaries" ]]; then
-  exit 0
-else
   exit 1
+else
+  exit 0
 fi


### PR DESCRIPTION
The current listed tests bellow:
- 6.1.14 Audit SGID executables (Not Scored)
- 6.1.13 Audit SUID executables (Not Scored)

Have changed the way to verify the binaries on the system to execute over multi cloud providers. For this step, are created bash files who identify where the machine was builded, and use specific count numbers for each situation.