### PR TITLE
.travis.yml: update goss version to v0.3.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: python
 before_install:
-  - sudo curl -L https://github.com/aelsabbahy/goss/releases/download/v0.3.6/goss-linux-amd64 -o /usr/local/bin/goss
+  - sudo curl -L https://github.com/aelsabbahy/goss/releases/download/v0.3.13/goss-linux-amd64 -o /usr/local/bin/goss
   - sudo chmod +rx /usr/local/bin/goss
 install:
   - pip install yamllint


### PR DESCRIPTION
This MR uptade the goss version to release: v0.3.13.